### PR TITLE
chore: Update Go version to 1.22.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,37 +16,16 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.21.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go-version }}
-
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # cache go modules
-      - uses: actions/cache@v3
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          # * Build cache (Windows)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: ./go.mod
 
       - name: Downloads the dependencies
         run: make download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exivity/pulumiconfig
 
-go 1.21.7
+go 1.22.3
 
 require (
 	github.com/go-playground/validator/v10 v10.18.0


### PR DESCRIPTION
This pull request updates the Go version in the go.mod file to 1.22.3. This ensures that the project is using the latest version of Go and takes advantage of any bug fixes or improvements in the new version.