### PR TITLE
chore: add pulumi test package

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,6 @@ By combining `StructValidation` and `FieldValidation`, you can enforce both glob
 
 - **Simplifies Testing**: Provides utility functions to compare Pulumi outputs and resources without writing boilerplate code.
 - **Fast Test Workflow**: Enables quick and efficient testing of Pulumi programs in Go.
-- **Integration with Testify**: Leverages the `testify` library for assertions, making it easy to integrate into existing test suites.
 
 
 ### Installation <a id="installation-1"></a>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
-# PulumiConfig
+### About the projects:
+<details>
+  <summary>Table of contents</summary>
+  <ol>
+    <li>
+      <a href="#pulumi-config">PulumiConfig Section</a>
+      <ul>
+        <li><a href="#features">Features</a></li>
+        <li><a href="#installation">Installation</a></li>
+        <li><a href="#usage">Usage</a></li>
+        <li><a href="#examples">Examples</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="#pulumi-test">PulumiTest Section</a>
+      <ul>
+        <li><a href="#features-1">Features</a></li>
+        <li><a href="#installation-1">Installation</a></li>
+        <li><a href="#usage-1">Usage</a></li>
+        <li><a href="#examples-1">Examples</a></li>
+      </ul>
+    </li>
+  </ol>
+</details>
+
+
+<!-- pulumi-config -->
+## PulumiConfig <a id="pulumi-config"></a>
 
 PulumiConfig is a Golang library designed to improve the way developers manage configuration in Pulumi. By leveraging Golang structs, it simplifies the process of tracking and validating configuration keys, ensuring a more efficient and error-free deployment process in cloud infrastructure projects.
 
-## Features
+### Features <a id="features"></a>
 
 - **Seamless Integration**: Effortlessly integrates with Pulumi and Golang projects.
 - **Automated Key Tracking**: Automatically tracks configuration keys using Golang structs.
@@ -10,7 +37,8 @@ PulumiConfig is a Golang library designed to improve the way developers manage c
 - **[go-playground/validator](https://github.com/go-playground/validator)**, letting you define both field- and struct-level validations., allowing required values and complex validations.
 - **Namespace Overrides**: Use `overrideConfigNamespace` to override specific fields with values from a different namespace.
 
-## Installation
+### Installation <a id="installation"></a>
+
 
 To integrate PulumiConfig into your Golang project, follow these steps:
 
@@ -151,7 +179,7 @@ func main() {
 
 You can use `overrideConfigNamespace` on any field-level struct tag. PulumiConfig will first load from the main namespace, and then—if `overrideConfigNamespace` is set—load the separate namespace and merge those values in.
 
-### Example: Custom Field and Struct Validators
+### Example: Custom Field and Struct Validators <a id="examples"></a>
 
 Below is a more in-depth example illustrating how you can combine PulumiConfig with the Pulumi DigitalOcean provider for domain-specific validation:
 
@@ -290,6 +318,119 @@ func main() {
 
 By combining `StructValidation` and `FieldValidation`, you can enforce both global and per-field checks for your Pulumi configurations. Adjust or extend as needed for your own providers or custom logic.
 
+
+
+
+
+<!-- pulumi-test -->
+## PulumiTest <a id="pulumi-test"></a>
+
+
+`pulumitest` is a Go package that provides helper functions to simplify testing Pulumi resources and outputs. It simplifies Pulumi testing by abstracting common patterns and offering intuitive assertions for resource validation.
+
+### Features <a id="features-1"></a>
+
+- **Simplifies Testing**: Provides utility functions to compare Pulumi outputs and resources without writing boilerplate code.
+- **Fast Test Workflow**: Enables quick and efficient testing of Pulumi programs in Go.
+- **Integration with Testify**: Leverages the `testify` library for assertions, making it easy to integrate into existing test suites.
+
+
+### Installation <a id="installation-1"></a>
+
+To use `pulumitest`, import it into your test files:
+
+```go
+import ("github.com/exivity/pulumiconfig/pkg/pulumitest")
+```
+
+## Usage
+
+### Basic Usage
+Below are the public functions provided by `pulumitest` and how to use them:
+
+```bash
+pulumitest.AssertStringOutputEqual(t, expectedOutput, actualOutput)
+pulumitest.AssertMapEqual(t, expectedMap, actualMap)
+pulumitest.AssertStringMapEqual(t, expectedStringMap, actualStringMap)
+```
+
+Sets the Pulumi configuration for a test.
+```bash
+pulumitest.SetPulumiConfig(t, map[string]string{
+    "key1": "value1",
+    "key2": "value2",
+})
+```
+
+### Example: Testing Map Outputs <a id="examples-1"></a>
+Compares two pulumi.MapOutput values and reports if they are not equal.
+
+```go
+package test
+
+import (
+    "testing"
+
+    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+    "github.com/exivity/pulumiconfig/pkg/pulumitest"
+)
+
+func TestAssertMapEqual(t *testing.T) {
+	type args struct {
+		expected   pulumi.MapOutput
+		actual     pulumi.MapOutput
+		msgAndArgs []interface{}
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantFailed bool
+	}{
+		{
+			name: "nil outputs", // Both maps are empty.
+			args: args{
+				expected: pulumi.Map{}.ToMapOutput(),
+				actual:   pulumi.Map{}.ToMapOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are equal", // Both maps have the same key-value pairs.
+			args: args{
+				expected: pulumi.Map{
+					"key": pulumi.String("value"),
+				}.ToMapOutput(),
+				actual: pulumi.Map{
+					"key": pulumi.String("value"),
+				}.ToMapOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are not equal", // Maps have different values for the same key.
+			args: args{
+				expected: pulumi.Map{
+					"key": pulumi.String("value"),
+				}.ToMapOutput(),
+				actual: pulumi.Map{
+					"key": pulumi.String(""),
+				}.ToMapOutput(),
+			},
+			wantFailed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testT := &testing.T{}
+			AssertMapEqual(testT, tt.args.expected, tt.args.actual, tt.args.msgAndArgs...)
+			assert.Equal(t, tt.wantFailed, testT.Failed())
+		})
+	}
+}
+
+```
+
 ## License
 
 PulumiConfig is released under MIT. See the [LICENSE](./LICENSE) file for more details.
+

--- a/pkg/pulumiconfig/validators_test.go
+++ b/pkg/pulumiconfig/validators_test.go
@@ -1,3 +1,6 @@
+// Package pulumiconfig contains tests for validating the behavior of utility functions.
+// This file specifically tests the `string2Number` function, which converts strings to numbers.
+
 package pulumiconfig
 
 import (
@@ -5,6 +8,8 @@ import (
 	"testing"
 )
 
+// It ensures that the function correctly converts strings to numeric types (e.g., int64, uint64, float64)
+// and handles invalid inputs or unsupported conversion types.
 func Test_string2Number(t *testing.T) {
 	type args struct {
 		s string

--- a/pkg/pulumitest/pulumitest.go
+++ b/pkg/pulumitest/pulumitest.go
@@ -26,10 +26,7 @@ import (
 
 // AssertStringOutputEqual compares two pulumi.StringOutput values
 // and uses testify to report if they are not equal.
-//
-// Usage:
-//
-//	pulumitest.AssertStringOutputEqual(t, expectedOutput, actualOutput)
+
 func AssertStringOutputEqual(t *testing.T, expected, actual pulumi.Output, msgAndArgs ...interface{}) {
 	wg := &sync.WaitGroup{}
 	var expectedValue, actualValue interface{}
@@ -58,10 +55,7 @@ func AssertStringOutputEqual(t *testing.T, expected, actual pulumi.Output, msgAn
 }
 
 // AssertMapEqual compares two pulumi.Map values and uses testify to report if they are not equal.
-//
-// Usage:
-//
-//	pulumitest.AssertMapEqual(t, expectedMap, actualMap)
+
 func AssertMapEqual(t *testing.T, expected, actual pulumi.MapOutput, msgAndArgs ...interface{}) {
 	wg := &sync.WaitGroup{}
 	var expectedValue, actualValue map[string]interface{}
@@ -90,10 +84,7 @@ func AssertMapEqual(t *testing.T, expected, actual pulumi.MapOutput, msgAndArgs 
 }
 
 // AssertStringMapEqual compares two pulumi.StringMap values and uses testify to report if they are not equal.
-//
-// Usage:
-//
-//	pulumitest.AssertStringMapEqual(t, expectedStringMap, actualStringMap)
+
 func AssertStringMapEqual(t *testing.T, expected, actual pulumi.StringMapOutput, msgAndArgs ...interface{}) {
 	wg := &sync.WaitGroup{}
 	var expectedValue, actualValue map[string]string
@@ -122,10 +113,7 @@ func AssertStringMapEqual(t *testing.T, expected, actual pulumi.StringMapOutput,
 }
 
 // AssertArrayEqual compares two pulumi.Array values and uses testify to report if they are not equal.
-//
-// Usage:
-//
-//	pulumitest.AssertArrayEqual(t, expectedArray, actualArray)
+
 func AssertArrayEqual(t *testing.T, expected, actual pulumi.ArrayOutput, msgAndArgs ...interface{}) {
 	wg := &sync.WaitGroup{}
 	var expectedValue, actualValue []interface{}

--- a/pkg/pulumitest/pulumitest.go
+++ b/pkg/pulumitest/pulumitest.go
@@ -1,0 +1,231 @@
+// Package pulumitest provides helper functions to facilitate testing
+// of Pulumi resources and outputs. This package utilizes testify to
+// offer assertions and comparisons tailored to Pulumi's constructs.
+//
+// Usage:
+//
+// In your tests, import this package and use its provided functions
+// to compare expected and actual Pulumi resources or outputs. The
+// functions in this package abstract away the repetitive tasks and
+// boilerplate, allowing you to focus on writing meaningful tests
+// for your Pulumi programs.
+package pulumitest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertStringOutputEqual compares two pulumi.StringOutput values
+// and uses testify to report if they are not equal.
+//
+// Usage:
+//
+//	pulumitest.AssertStringOutputEqual(t, expectedOutput, actualOutput)
+func AssertStringOutputEqual(t *testing.T, expected, actual pulumi.Output, msgAndArgs ...interface{}) {
+	wg := &sync.WaitGroup{}
+	var expectedValue, actualValue interface{}
+	wg.Add(2) //nolint:mnd // We need to wait for two goroutines.
+
+	applyFunc := func(output pulumi.Output, target *interface{}) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Logf("Recovered from panic while applying output: %v", r)
+			}
+		}()
+		output.ApplyT(func(v interface{}) interface{} {
+			defer wg.Done()
+			*target = getPointerValue(v)
+			return nil
+		})
+	}
+
+	go applyFunc(expected, &expectedValue)
+	go applyFunc(actual, &actualValue)
+
+	wg.Wait()
+
+	msgAndArgs = append(msgAndArgs, "Pulumi string outputs are not equal")
+	assert.Equal(t, expectedValue, actualValue, msgAndArgs...)
+}
+
+// AssertMapEqual compares two pulumi.Map values and uses testify to report if they are not equal.
+//
+// Usage:
+//
+//	pulumitest.AssertMapEqual(t, expectedMap, actualMap)
+func AssertMapEqual(t *testing.T, expected, actual pulumi.MapOutput, msgAndArgs ...interface{}) {
+	wg := &sync.WaitGroup{}
+	var expectedValue, actualValue map[string]interface{}
+	wg.Add(2) //nolint:mnd // We need to wait for two goroutines.
+
+	applyFunc := func(output pulumi.MapOutput, target *map[string]interface{}) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Logf("Recovered from panic while applying MapOutput: %v", r)
+			}
+		}()
+		output.ApplyT(func(v map[string]interface{}) interface{} {
+			defer wg.Done()
+			*target = v
+			return nil
+		})
+	}
+
+	go applyFunc(expected, &expectedValue)
+	go applyFunc(actual, &actualValue)
+
+	wg.Wait()
+
+	msgAndArgs = append(msgAndArgs, "Pulumi Map outputs are not equal")
+	assert.Equal(t, expectedValue, actualValue, msgAndArgs...)
+}
+
+// AssertStringMapEqual compares two pulumi.StringMap values and uses testify to report if they are not equal.
+//
+// Usage:
+//
+//	pulumitest.AssertStringMapEqual(t, expectedStringMap, actualStringMap)
+func AssertStringMapEqual(t *testing.T, expected, actual pulumi.StringMapOutput, msgAndArgs ...interface{}) {
+	wg := &sync.WaitGroup{}
+	var expectedValue, actualValue map[string]string
+	wg.Add(2) //nolint:mnd // We need to wait for two goroutines.
+
+	applyFunc := func(output pulumi.StringMapOutput, target *map[string]string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Logf("Recovered from panic while applying MapOutput: %v", r)
+			}
+		}()
+		output.ApplyT(func(v map[string]string) interface{} {
+			defer wg.Done()
+			*target = v
+			return nil
+		})
+	}
+
+	go applyFunc(expected, &expectedValue)
+	go applyFunc(actual, &actualValue)
+
+	wg.Wait()
+
+	msgAndArgs = append(msgAndArgs, "Pulumi StringMap outputs are not equal")
+	assert.Equal(t, expectedValue, actualValue, msgAndArgs...)
+}
+
+// AssertArrayEqual compares two pulumi.Array values and uses testify to report if they are not equal.
+//
+// Usage:
+//
+//	pulumitest.AssertArrayEqual(t, expectedArray, actualArray)
+func AssertArrayEqual(t *testing.T, expected, actual pulumi.ArrayOutput, msgAndArgs ...interface{}) {
+	wg := &sync.WaitGroup{}
+	var expectedValue, actualValue []interface{}
+	wg.Add(2) //nolint:mnd // We need to wait for two goroutines.
+
+	applyFunc := func(output pulumi.ArrayOutput, target *[]interface{}) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Logf("Recovered from panic while applying ArrayOutput: %v", r)
+			}
+		}()
+		output.ApplyT(func(v []interface{}) interface{} {
+			defer wg.Done()
+			*target = v
+			return nil
+		})
+	}
+
+	go applyFunc(expected, &expectedValue)
+	go applyFunc(actual, &actualValue)
+
+	wg.Wait()
+
+	msgAndArgs = append(msgAndArgs, "Pulumi Array outputs are not equal")
+	assert.Equal(t, expectedValue, actualValue, msgAndArgs...)
+}
+
+// getPointerValue dereferences a pointer value until it reaches the base value.
+// If the input is not a pointer, the original value is returned.
+// For nil pointers, the function will return nil.
+func getPointerValue(v interface{}) interface{} {
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			// Return a clear indication for nil pointers.
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	return rv.Interface()
+}
+
+// AssertResourceEqual compares two Pulumi resources and reports any differences using testify.
+// It handles Pulumi specific types like pulumi.Output by delegating to specific assert functions.
+// Other fields are compared using standard testify assert methods.
+func AssertResourceEqual(t *testing.T, expected, actual interface{}, fields []string, msgAndArgs ...interface{}) {
+	expectedValue := getPointerValue(expected)
+	actualValue := getPointerValue(actual)
+
+	expectedType := reflect.TypeOf(expectedValue)
+	actualType := reflect.TypeOf(actualValue)
+
+	assert.Equal(t, expectedType, actualType, "Types of resources are not the same.")
+
+	if expectedType != actualType {
+		return
+	}
+
+	expectedVal := reflect.ValueOf(expectedValue)
+	actualVal := reflect.ValueOf(actualValue)
+
+	compareAll := len(fields) == 0
+
+	// Loop through fields of the struct.
+	for i := 0; i < expectedVal.NumField(); i++ {
+		fieldName := expectedType.Field(i).Name // get the field's name
+
+		if !compareAll && !slices.Contains(fields, fieldName) {
+			continue
+		}
+
+		if fieldName == "CustomResourceState" {
+			continue
+		}
+
+		expectedField := expectedVal.Field(i)
+		actualField := actualVal.Field(i)
+
+		// Get the type of each field.
+		expectedFieldType := expectedField.Type()
+		actualFieldType := actualField.Type()
+
+		// Check if the field is of type pulumi.Output.
+		if expectedFieldType.Implements(reflect.TypeOf((*pulumi.Output)(nil)).Elem()) && actualFieldType.Implements(reflect.TypeOf((*pulumi.Output)(nil)).Elem()) {
+			expectedOutput := expectedField.Interface().(pulumi.Output)
+			actualOutput := actualField.Interface().(pulumi.Output)
+			// AssertStringOutputEqual(t, expectedOutput, actualOutput)
+			AssertStringOutputEqual(t, expectedOutput, actualOutput, append(msgAndArgs, fmt.Sprintf("Field '%s' mismatch.", fieldName))...)
+		} else {
+			// If it's not a pulumi.CustomResourceState, use standard testify assertion.
+			assert.Equal(t, expectedField.Interface(), actualField.Interface(), fmt.Sprintf("Field '%s' mismatch.", fieldName), msgAndArgs)
+		}
+	}
+}
+
+// SetPulumiConfig sets the Pulumi config for the test.
+func SetPulumiConfig(t *testing.T, config map[string]string) {
+	jsonConfig, err := json.Marshal(config)
+	assert.NoError(t, err, "Error marshaling to JSON")
+
+	err = os.Setenv(pulumi.EnvConfig, string(jsonConfig))
+	assert.NoError(t, err)
+}

--- a/pkg/pulumitest/pulumitest_test.go
+++ b/pkg/pulumitest/pulumitest_test.go
@@ -1,3 +1,6 @@
+// Package pulumitest provides helper functions to test Pulumi outputs.
+// These helpers make it easier to compare Pulumi outputs in unit tests.
+
 package pulumitest
 
 import (
@@ -7,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestAssertStringOutputEqual checks if two Pulumi string outputs are the same.
+// It ensures that the AssertStringOutputEqual function works as expected.
 func TestAssertStringOutputEqual(t *testing.T) {
 	type args struct {
 		expected   pulumi.Output
@@ -19,7 +24,7 @@ func TestAssertStringOutputEqual(t *testing.T) {
 		wantFailed bool
 	}{
 		{
-			name: "nil outputs",
+			name: "nil outputs", // Both outputs are empty strings.
 			args: args{
 				expected: pulumi.String("").ToStringOutput(),
 				actual:   pulumi.String("").ToStringOutput(),
@@ -27,7 +32,7 @@ func TestAssertStringOutputEqual(t *testing.T) {
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are equal",
+			name: "expect and actual are equal", // Both outputs have the same value.
 			args: args{
 				expected: pulumi.String("123").ToStringOutput(),
 				actual:   pulumi.String("123").ToStringOutput(),
@@ -35,7 +40,7 @@ func TestAssertStringOutputEqual(t *testing.T) {
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are not equal",
+			name: "expect and actual are not equal", // Outputs have different values.
 			args: args{
 				expected: pulumi.String("123").ToStringOutput(),
 				actual:   pulumi.String("").ToStringOutput(),
@@ -52,6 +57,8 @@ func TestAssertStringOutputEqual(t *testing.T) {
 	}
 }
 
+// TestAssertMapEqual checks if two Pulumi map outputs are the same.
+// It ensures that the AssertMapEqual function works expected.
 func TestAssertMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
 	type args struct {
 		expected   pulumi.MapOutput
@@ -64,7 +71,7 @@ func TestAssertMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
 		wantFailed bool
 	}{
 		{
-			name: "nil outputs",
+			name: "nil outputs", // Both maps are empty.
 			args: args{
 				expected: pulumi.Map{}.ToMapOutput(),
 				actual:   pulumi.Map{}.ToMapOutput(),
@@ -72,7 +79,7 @@ func TestAssertMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are equal",
+			name: "expect and actual are equal", // Both maps have the same key-value pairs.
 			args: args{
 				expected: pulumi.Map{
 					"key": pulumi.String("value"),
@@ -84,7 +91,7 @@ func TestAssertMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are not equal",
+			name: "expect and actual are not equal", // Maps have different values for the same key.
 			args: args{
 				expected: pulumi.Map{
 					"key": pulumi.String("value"),
@@ -105,6 +112,8 @@ func TestAssertMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
 	}
 }
 
+// TestAssertStringMapEqual checks if two Pulumi string map outputs are the same.
+// It ensures that the AssertStringMapEqual function works correctly.
 func TestAssertStringMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
 	type args struct {
 		expected   pulumi.StringMapOutput
@@ -117,7 +126,7 @@ func TestAssertStringMapEqual(t *testing.T) { //nolint:dupl // test cases are si
 		wantFailed bool
 	}{
 		{
-			name: "nil outputs",
+			name: "nil outputs", // Both string maps are empty.
 			args: args{
 				expected: pulumi.StringMap{}.ToStringMapOutput(),
 				actual:   pulumi.StringMap{}.ToStringMapOutput(),
@@ -125,7 +134,7 @@ func TestAssertStringMapEqual(t *testing.T) { //nolint:dupl // test cases are si
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are equal",
+			name: "expect and actual are equal", // Both string maps have the same key-value pairs.
 			args: args{
 				expected: pulumi.StringMap{
 					"key": pulumi.String("value"),
@@ -137,7 +146,7 @@ func TestAssertStringMapEqual(t *testing.T) { //nolint:dupl // test cases are si
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are not equal",
+			name: "expect and actual are not equal", // String maps have different values for the same key.
 			args: args{
 				expected: pulumi.StringMap{
 					"key": pulumi.String("value"),
@@ -158,6 +167,8 @@ func TestAssertStringMapEqual(t *testing.T) { //nolint:dupl // test cases are si
 	}
 }
 
+// TestAssertArrayEqual checks if two Pulumi array outputs are the same.
+// It ensures that the AssertArrayEqual function works correctly.
 func TestAssertArrayEqual(t *testing.T) {
 	type args struct {
 		expected   pulumi.ArrayOutput
@@ -170,7 +181,7 @@ func TestAssertArrayEqual(t *testing.T) {
 		wantFailed bool
 	}{
 		{
-			name: "nil outputs",
+			name: "nil outputs", // Both arrays are empty.
 			args: args{
 				expected: pulumi.Array{}.ToArrayOutput(),
 				actual:   pulumi.Array{}.ToArrayOutput(),
@@ -178,7 +189,7 @@ func TestAssertArrayEqual(t *testing.T) {
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are equal",
+			name: "expect and actual are equal", // Both arrays have the same values.
 			args: args{
 				expected: pulumi.Array{
 					pulumi.String("value"),
@@ -190,7 +201,7 @@ func TestAssertArrayEqual(t *testing.T) {
 			wantFailed: false,
 		},
 		{
-			name: "expect and actual are not equal",
+			name: "expect and actual are not equal", // Arrays have different values.
 			args: args{
 				expected: pulumi.Array{
 					pulumi.String("value"),

--- a/pkg/pulumitest/pulumitest_test.go
+++ b/pkg/pulumitest/pulumitest_test.go
@@ -1,0 +1,210 @@
+package pulumitest
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertStringOutputEqual(t *testing.T) {
+	type args struct {
+		expected   pulumi.Output
+		actual     pulumi.Output
+		msgAndArgs []interface{}
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantFailed bool
+	}{
+		{
+			name: "nil outputs",
+			args: args{
+				expected: pulumi.String("").ToStringOutput(),
+				actual:   pulumi.String("").ToStringOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are equal",
+			args: args{
+				expected: pulumi.String("123").ToStringOutput(),
+				actual:   pulumi.String("123").ToStringOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are not equal",
+			args: args{
+				expected: pulumi.String("123").ToStringOutput(),
+				actual:   pulumi.String("").ToStringOutput(),
+			},
+			wantFailed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testT := &testing.T{}
+			AssertStringOutputEqual(testT, tt.args.expected, tt.args.actual, tt.args.msgAndArgs...)
+			assert.Equal(t, tt.wantFailed, testT.Failed())
+		})
+	}
+}
+
+func TestAssertMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
+	type args struct {
+		expected   pulumi.MapOutput
+		actual     pulumi.MapOutput
+		msgAndArgs []interface{}
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantFailed bool
+	}{
+		{
+			name: "nil outputs",
+			args: args{
+				expected: pulumi.Map{}.ToMapOutput(),
+				actual:   pulumi.Map{}.ToMapOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are equal",
+			args: args{
+				expected: pulumi.Map{
+					"key": pulumi.String("value"),
+				}.ToMapOutput(),
+				actual: pulumi.Map{
+					"key": pulumi.String("value"),
+				}.ToMapOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are not equal",
+			args: args{
+				expected: pulumi.Map{
+					"key": pulumi.String("value"),
+				}.ToMapOutput(),
+				actual: pulumi.Map{
+					"key": pulumi.String(""),
+				}.ToMapOutput(),
+			},
+			wantFailed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testT := &testing.T{}
+			AssertMapEqual(testT, tt.args.expected, tt.args.actual, tt.args.msgAndArgs...)
+			assert.Equal(t, tt.wantFailed, testT.Failed())
+		})
+	}
+}
+
+func TestAssertStringMapEqual(t *testing.T) { //nolint:dupl // test cases are similar
+	type args struct {
+		expected   pulumi.StringMapOutput
+		actual     pulumi.StringMapOutput
+		msgAndArgs []interface{}
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantFailed bool
+	}{
+		{
+			name: "nil outputs",
+			args: args{
+				expected: pulumi.StringMap{}.ToStringMapOutput(),
+				actual:   pulumi.StringMap{}.ToStringMapOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are equal",
+			args: args{
+				expected: pulumi.StringMap{
+					"key": pulumi.String("value"),
+				}.ToStringMapOutput(),
+				actual: pulumi.StringMap{
+					"key": pulumi.String("value"),
+				}.ToStringMapOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are not equal",
+			args: args{
+				expected: pulumi.StringMap{
+					"key": pulumi.String("value"),
+				}.ToStringMapOutput(),
+				actual: pulumi.StringMap{
+					"key": pulumi.String(""),
+				}.ToStringMapOutput(),
+			},
+			wantFailed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testT := &testing.T{}
+			AssertStringMapEqual(testT, tt.args.expected, tt.args.actual, tt.args.msgAndArgs...)
+			assert.Equal(t, tt.wantFailed, testT.Failed())
+		})
+	}
+}
+
+func TestAssertArrayEqual(t *testing.T) {
+	type args struct {
+		expected   pulumi.ArrayOutput
+		actual     pulumi.ArrayOutput
+		msgAndArgs []interface{}
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantFailed bool
+	}{
+		{
+			name: "nil outputs",
+			args: args{
+				expected: pulumi.Array{}.ToArrayOutput(),
+				actual:   pulumi.Array{}.ToArrayOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are equal",
+			args: args{
+				expected: pulumi.Array{
+					pulumi.String("value"),
+				}.ToArrayOutput(),
+				actual: pulumi.Array{
+					pulumi.String("value"),
+				}.ToArrayOutput(),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "expect and actual are not equal",
+			args: args{
+				expected: pulumi.Array{
+					pulumi.String("value"),
+				}.ToArrayOutput(),
+				actual: pulumi.Array{}.ToArrayOutput(),
+			},
+			wantFailed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testT := &testing.T{}
+			AssertArrayEqual(testT, tt.args.expected, tt.args.actual, tt.args.msgAndArgs...)
+			assert.Equal(t, tt.wantFailed, testT.Failed())
+		})
+	}
+}


### PR DESCRIPTION
Move pulumitest package from EaaS deployment to pulumi config.

Close-[EXVT-5957](https://exivity.atlassian.net/browse/EXVT-5957)

[EXVT-5957]: https://exivity.atlassian.net/browse/EXVT-5957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ