### PR TITLE
chore: Update golangci-lint to version 2.1.6

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,61 +1,73 @@
+version: "2"
 run:
-  timeout: 10m
   issues-exit-code: 1
   tests: true
-
 linters:
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/
   enable:
-    - cyclop # Go linter that checks if package imports are in a list of acceptable packages
-    - depguard # Go linter that checks if package imports are in a list of acceptable packages
-    - dogsled # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
-    - dupl # Tool for code clone detection
-    - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exhaustive # check exhaustiveness of enum switch statements
-    - copyloopvar # checks for pointers to enclosing loop variables
-    - funlen # Tool for detection of long functions
-    - gochecknoglobals # A global variable is a variable declared in package scope and that can be read and written to by any function within the package.
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - goconst # Inspects source code for security problems
-    - gocyclo # Computes and checks the cyclomatic complexity of functions
-    - err113 # Golang linter to check the errors handling expressions
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt.
-    - mnd # An analyzer to detect magic numbers.
-    - goprintffuncname # Checks that printf-like functions are named with f at the end
-    - gosec # Inspects source code for security problems
-    - misspell # Finds commonly misspelled English words in comments
-    - nakedret # Finds naked returns in functions greater than a specified function length
-    - nestif # Reports deeply nested if statements
-    - nilerr # Finds the code that returns nil even if it checks that the error is not nil.
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - prealloc # Finds slice declarations that could potentially be pre-allocated
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - unconvert # Remove unnecessary type conversions
-    - unparam # Reports unused function parameters
-    - whitespace # Tool for detection of leading and trailing whitespace
-
-linters-settings:
-  funlen:
-    lines: 100
-    statements: 50
-  depguard:
+    - copyloopvar
+    - cyclop
+    - depguard
+    - dogsled
+    - dupl
+    - err113
+    - errorlint
+    - exhaustive
+    - funlen
+    - gochecknoglobals
+    - goconst
+    - gocritic
+    - gocyclo
+    - goprintffuncname
+    - gosec
+    - misspell
+    - mnd
+    - nakedret
+    - nestif
+    - nilerr
+    - nolintlint
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
+  settings:
+    depguard:
+      rules:
+        main:
+          allow:
+            - $gostd
+            - github.com/pulumi/pulumi/sdk/v3/go
+            - github.com/go-playground/validator/v10
+            - github.com/stretchr/testify/assert
+            - dario.cat/mergo
+    funlen:
+      lines: 100
+      statements: 50
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        allow:
-          - $gostd
-          - github.com/pulumi/pulumi/sdk/v3/go
-          - github.com/go-playground/validator/v10
-          - github.com/stretchr/testify/assert
-          - dario.cat/mergo
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gochecknoglobals
-        - gosec
-        - funlen
-        - noctx
+      - linters:
+          - funlen
+          - gochecknoglobals
+          - gosec
+          - noctx
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash -e -o pipefail
 PWD = $(shell pwd)
 
 # constants
-GOLANGCI_VERSION = 1.61.0
+GOLANGCI_VERSION = 2.1.6
 
 out:
 	@mkdir -p out


### PR DESCRIPTION
Upgrade the golangci-lint version to improve linting capabilities and maintainability of the codebase. Adjustments to the linter configuration reflect the new version's features and settings.